### PR TITLE
feat: allow create Release externally with project-specific API Key authorization

### DIFF
--- a/components/Account/Profile.vue
+++ b/components/Account/Profile.vue
@@ -77,11 +77,8 @@ function handleReset() {
 async function updateAccount() {
   const formData = new FormData()
 
-  formData.append('data', JSON.stringify({
-    name: model.value.name,
-    picture: model.value.picture,
-  }))
-
+  model.value.name && formData.append('name', model.value.name)
+  model.value.picture && formData.append('picture', model.value.picture)
   model.value.file && formData.append('file', model.value.file)
 
   await useNuxtApp().$auth.fetch('/api/account/profile', {

--- a/components/Project/Metadata.vue
+++ b/components/Project/Metadata.vue
@@ -6,11 +6,25 @@
     :model="model"
     @submit.prevent="onSubmit(handleSubmit)"
   >
+    <n-form-item label="Identifier">
+      <n-input
+        :value="project.id"
+        disabled
+      />
+    </n-form-item>
+
     <n-form-item
       label="Name"
       path="name"
     >
       <n-input v-model:value="model.name" />
+    </n-form-item>
+
+    <n-form-item
+      label="API key"
+      path="apiKey"
+    >
+      <form-key v-model:value="model.apiKey" />
     </n-form-item>
 
     <n-form-item
@@ -46,6 +60,7 @@ const model = ref({
   name: props.project.name,
   repository: props.project.repository,
   description: props.project.description,
+  apiKey: undefined,
 })
 
 const { apiErrors, formRef, onSubmit, pending, rules, reset, edited }

--- a/composables/useProject.ts
+++ b/composables/useProject.ts
@@ -63,6 +63,7 @@ export default function useProject() {
         description: data.description || null,
         variables: data.variables || null,
         commands: data.commands || null,
+        apiKey: data.apiKey || null,
       },
 
       onResponse: ({ response }) => {

--- a/composables/useRelease.ts
+++ b/composables/useRelease.ts
@@ -28,11 +28,8 @@ export default function useRelease(projectId: Project['id']) {
   function add(version: Release['version'], firmware: File) {
     const formData = new FormData()
 
-    formData.append('data', JSON.stringify({
-      version,
-      projectId,
-    }))
-
+    formData.append('version', version)
+    formData.append('projectId', projectId)
     formData.append('file', firmware)
 
     return $auth.fetch('/api/releases', {

--- a/prisma/mongo.schema.prisma
+++ b/prisma/mongo.schema.prisma
@@ -69,6 +69,7 @@ model Report {
 model Project {
   id          String    @id @default(auto()) @map("_id") @db.ObjectId
   name        String
+  apiKey      String?
   repository  String?
   description String?
   variables   String?

--- a/prisma/sql.schema.prisma
+++ b/prisma/sql.schema.prisma
@@ -69,6 +69,7 @@ model Report {
 model Project {
     id          String    @id @default(uuid())
     name        String
+    apiKey      String?
     repository  String?
     description String?
     variables   String?

--- a/server/api/account/profile.patch.ts
+++ b/server/api/account/profile.patch.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
   const multipart = await validateMultipartFormData(event, schema)
 
   if (multipart.file) {
-    multipart.picture = await uploadObject(event, multipart.file, multipart.picture)
+    multipart.picture = await uploadObject(multipart.file, userId, multipart.picture)
   }
 
   const user = await event.context.prisma.user

--- a/server/api/devices/[id]/index.patch.ts
+++ b/server/api/devices/[id]/index.patch.ts
@@ -8,9 +8,9 @@ export default defineEventHandler(async (event) => {
   const schema = z.object({
     name: z.string().min(1).optional(),
     apiKey: z.string().min(1).optional(),
-    description: z.string().nullable().optional(),
+    description: z.string().min(1).nullable().optional(),
     status: z.enum(['connected', 'disconnected', 'unregistered']).optional(),
-    variables: z.string().optional().nullable(),
+    variables: z.string().min(1).nullable().optional(),
   })
 
   const body = await validateBody(event, schema)

--- a/server/api/projects/[id]/index.get.ts
+++ b/server/api/projects/[id]/index.get.ts
@@ -8,6 +8,16 @@ export default defineEventHandler(async (event) => {
       id: projectId,
       userId,
     },
+    select: {
+      id: true,
+      name: true,
+      repository: true,
+      description: true,
+      commands: true,
+      variables: true,
+      createdAt: true,
+      updatedAt: true,
+    },
   }).catch((err) => { throw createPrismaError(err) })
 
   return project

--- a/server/api/projects/[id]/index.patch.ts
+++ b/server/api/projects/[id]/index.patch.ts
@@ -1,3 +1,5 @@
+import { hashSync } from '#auth'
+
 export default defineEventHandler(async (event) => {
   const { userId } = checkUser(event)
 
@@ -14,6 +16,12 @@ export default defineEventHandler(async (event) => {
 
   const body = await validateBody(event, schema)
 
+  let hashedApiKey = undefined
+
+  if (body.apiKey) {
+    hashedApiKey = hashSync(body.apiKey, 12)
+  }
+
   const project = await event.context.prisma.project.update({
     where: {
       id: projectId,
@@ -25,7 +33,7 @@ export default defineEventHandler(async (event) => {
       repository: body.repository,
       commands: body.commands,
       variables: body.variables,
-      apiKey: body.apiKey,
+      apiKey: hashedApiKey,
     },
     select: {
       id: true,

--- a/server/api/projects/[id]/index.patch.ts
+++ b/server/api/projects/[id]/index.patch.ts
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event) => {
     description: z.string().nullable().optional(),
     variables: z.string().optional().nullable(),
     commands: z.string().optional().nullable(),
+    apiKey: z.string().min(1).optional().nullable(),
   })
 
   const body = await validateBody(event, schema)
@@ -24,6 +25,17 @@ export default defineEventHandler(async (event) => {
       repository: body.repository,
       commands: body.commands,
       variables: body.variables,
+      apiKey: body.apiKey,
+    },
+    select: {
+      id: true,
+      name: true,
+      repository: true,
+      description: true,
+      commands: true,
+      variables: true,
+      createdAt: true,
+      updatedAt: true,
     },
   }).catch((err) => { throw createPrismaError(err) })
 

--- a/server/api/projects/[id]/index.patch.ts
+++ b/server/api/projects/[id]/index.patch.ts
@@ -6,10 +6,10 @@ export default defineEventHandler(async (event) => {
   const schema = z.object({
     name: z.string().min(1).optional(),
     repository: z.string().url().nullable().optional(),
-    description: z.string().nullable().optional(),
-    variables: z.string().optional().nullable(),
-    commands: z.string().optional().nullable(),
-    apiKey: z.string().min(1).optional().nullable(),
+    description: z.string().min(1).nullable().optional(),
+    variables: z.string().min(1).nullable().optional(),
+    commands: z.string().min(1).nullable().optional(),
+    apiKey: z.string().min(1).nullable().optional(),
   })
 
   const body = await validateBody(event, schema)

--- a/server/api/releases/index.post.ts
+++ b/server/api/releases/index.post.ts
@@ -12,9 +12,9 @@ export default defineEventHandler(async (event) => {
 
   let userId = ''
 
-  const query = getQuery<{ ci: boolean }>(event)
+  const query = getQuery<{ ci: string }>(event)
 
-  if (query.ci === true) {
+  if (query.ci === 'true') {
     const project = await checkProject(event, multipart.projectId)
     userId = project.userId
   }
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
     userId = checkUser(event).userId
   }
 
-  const downloadPath = await uploadObject(event, multipart.file)
+  const downloadPath = await uploadObject(multipart.file, userId)
 
   const [release, mqttSettings] = await event.context.prisma.$transaction([
     event.context.prisma.release.create({

--- a/server/api/releases/index.post.ts
+++ b/server/api/releases/index.post.ts
@@ -2,8 +2,6 @@ import mqtt from 'mqtt'
 import { consola } from 'consola'
 
 export default defineEventHandler(async (event) => {
-  const { userId } = checkUser(event)
-
   const schema = z.object({
     version: z.string().regex(REGEX_VERSION),
     projectId: z.string().regex(REGEX_ID),
@@ -11,6 +9,18 @@ export default defineEventHandler(async (event) => {
   })
 
   const multipart = await validateMultipartFormData(event, schema)
+
+  let userId = ''
+
+  const query = getQuery<{ ci: boolean }>(event)
+
+  if (query.ci === true) {
+    const project = await checkProject(event, multipart.projectId)
+    userId = project.userId
+  }
+  else {
+    userId = checkUser(event).userId
+  }
 
   const downloadPath = await uploadObject(event, multipart.file)
 

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -30,6 +30,33 @@ export async function checkDevice(event: H3Event) {
   return device
 }
 
+export async function checkProject(event: H3Event) {
+  const projectId = event.context.params?.id
+
+  const apiKey = getHeader(event, 'Api-Key')
+
+  if (!apiKey || !projectId || !REGEX_ID.test(projectId)) {
+    throw createUnauthorizedError()
+  }
+
+  const project = await event.context.prisma.project.findUniqueOrThrow({
+    where: {
+      id: projectId,
+    },
+    select: {
+      id: true,
+      userId: true,
+      apiKey: true,
+    },
+  }).catch((err) => { throw createPrismaError(err) })
+
+  if (!compareSync(apiKey, project.apiKey)) {
+    throw createUnauthorizedError()
+  }
+
+  return project
+}
+
 export function checkUser(event: H3Event) {
   if (event.context.auth) {
     return event.context.auth

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,6 +1,5 @@
 import type { H3Event } from 'h3'
 import { compareSync } from '#auth'
-import { getKey } from '#s3'
 
 export async function checkDevice(event: H3Event) {
   const deviceId = event.context.params?.id
@@ -36,16 +35,4 @@ export function checkUser(event: H3Event) {
     return event.context.auth
   }
   throw createUnauthorizedError()
-}
-
-export function checkUpload(event: H3Event) {
-  const { userId } = checkUser(event)
-
-  const key = getKey(event)
-
-  const userIdFromKey = key.split('/')[0]
-
-  if (userId !== userIdFromKey) {
-    throw createUnauthorizedError()
-  }
 }

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -30,9 +30,7 @@ export async function checkDevice(event: H3Event) {
   return device
 }
 
-export async function checkProject(event: H3Event) {
-  const projectId = event.context.params?.id
-
+export async function checkProject(event: H3Event, projectId: Project['id']) {
   const apiKey = getHeader(event, 'Api-Key')
 
   if (!apiKey || !projectId || !REGEX_ID.test(projectId)) {

--- a/server/utils/s3.ts
+++ b/server/utils/s3.ts
@@ -20,9 +20,7 @@ export async function deleteObject(url: string) {
   }
 }
 
-export async function uploadObject(event: H3Event, file: MultiPartData, url?: string) {
-  const { userId } = checkUser(event)
-
+export async function uploadObject(file: MultiPartData, userId: string, url?: string) {
   const ext = file.filename?.split('.').pop()
 
   z.string().min(3).parse(ext)


### PR DESCRIPTION
This PR introduces a new API to create project releases which previously only supported manually via the web application.

- The user should set an API key for a specific project.
- A new release can be created, meaning on the database with firmware binary upload and mqtt update message published, via a fetch request to  `[POST] /api/releases?ci=true` with API key passed on `Api-Key` header and a form data body with fields `version` `projectId` `file`.

```bash
curl -X POST https://app.esp-admin.tn/api/releases?ci=true ^
-H "Api-Key:API_KEY" ^
-F "projectId=PROJECT_ID" ^
-F "version=VERSION" ^
-F "file=@.pio\build\esp32dev\firmware.bin"
```